### PR TITLE
Update alert forwarding

### DIFF
--- a/csdl.sln.DotSettings
+++ b/csdl.sln.DotSettings
@@ -1,4 +1,4 @@
-<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/CodeInspection/ExcludedFiles/FileMasksToSkip/=_002A_002Ejs/@EntryIndexedValue">False</s:Boolean>
     <s:Boolean x:Key="/Default/CodeInspection/ExcludedFiles/FileMasksToSkip/=_002A_002Ejs/@EntryIndexRemoved">True</s:Boolean>
     <s:Boolean x:Key="/Default/CodeInspection/ExcludedFiles/FileMasksToSkip/=_002A_002E_002Ass/@EntryIndexedValue">True</s:Boolean>
@@ -261,8 +261,8 @@ Licensed under Apache-2.0 - see the license file for more information</s:String>
     <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=VirtualMemberNeverOverridden_002EGlobal/@EntryIndexedValue">HINT</s:String>
     <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=VirtualMemberNeverOverridden_002ELocal/@EntryIndexedValue">WARNING</s:String>
     <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=WrongIndentSize/@EntryIndexedValue">WARNING</s:String>
-    <s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=AS/@EntryIndexedValue">AS</s:String>
-    <s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=ASN/@EntryIndexedValue">ASN</s:String>
+    <s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=DHT/@EntryIndexedValue">DHT</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IP/@EntryIndexedValue">IP</s:String>
     <s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EFeature_002EServices_002ECodeCleanup_002EFileHeader_002EFileHeaderSettingsMigrate/@EntryIndexedValue">True</s:Boolean>
     <s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
     <s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>

--- a/csdl/Enums/AlertCategories.cs
+++ b/csdl/Enums/AlertCategories.cs
@@ -1,0 +1,66 @@
+// csdl - a cross-platform libtorrent wrapper for .NET
+// Licensed under Apache-2.0 - see the license file for more information
+
+using System;
+
+namespace csdl.Enums;
+
+/// <summary>
+/// The categories to receive status alerts for. Some categories may only produce a generic alert due to specific structs not being implemented .NET side.
+/// </summary>
+/// <remarks>
+/// The enum <see cref="AlertType"/> refers to specific alerts that have .NET structs implemented.
+/// </remarks>
+[Flags]
+public enum AlertCategories
+{
+    None = 0,
+
+    Error = 1 << 0,
+    Peer = 1 << 1,
+    PortMapping = 1 << 2,
+    Storage = 1 << 3,
+    Tracker = 1 << 4,
+    Connect = 1 << 5,
+    Status = 1 << 6,
+    IPBlock = 1 << 8,
+    PerformanceWarning = 1 << 9,
+    DHT = 1 << 10,
+    Stats = 1 << 11,
+    SessionLog = 1 << 13,
+    TorrentLog = 1 << 14,
+    PeerLog = 1 << 15,
+    IncomingRequest = 1 << 16,
+    DHTLog = 1 << 17,
+    DHTOperation = 1 << 18,
+    PortMappingLog = 1 << 19,
+    PickerLog = 1 << 20,
+    FileProgress = 1 << 21,
+    PieceProgress = 1 << 22,
+    Upload = 1 << 23,
+    BlockProgress = 1 << 24,
+
+    All = Error |
+          Peer |
+          PortMapping |
+          Storage |
+          Tracker |
+          Connect |
+          Status |
+          IPBlock |
+          PerformanceWarning |
+          DHT |
+          Stats |
+          SessionLog |
+          TorrentLog |
+          PeerLog |
+          IncomingRequest |
+          DHTLog |
+          DHTOperation |
+          PortMappingLog |
+          PickerLog |
+          FileProgress |
+          PieceProgress |
+          Upload |
+          BlockProgress
+}

--- a/csdl/Native/NativeStructs.cs
+++ b/csdl/Native/NativeStructs.cs
@@ -20,10 +20,12 @@ internal static class NativeStructs
         [MarshalAs(UnmanagedType.LPStr)]
         public string fingerprint;
 
-        public bool all_events;
         public bool private_mode;
         public bool block_seeding;
         public bool force_encryption;
+
+        public bool set_alert_flags;
+        public uint alert_flags;
 
         public int max_connections;
     }

--- a/csdl/TorrentClient.cs
+++ b/csdl/TorrentClient.cs
@@ -50,7 +50,7 @@ public class TorrentClient : IDisposable
 
         if (_handle <= IntPtr.Zero)
         {
-            throw new InvalidOperationException("Failed to create session.");
+            throw new InvalidOperationException($"Failed to create session ({_handle}.");
         }
 
         _eventCallback = ProxyRaisedEvent;
@@ -180,17 +180,14 @@ public class TorrentClient : IDisposable
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
-        if (!_attachedManagers.TryRemove(manager.Info.Metadata.InfoHash, out _))
+        // the manager is fully removed via the alert callback (fires once the torrent is fully removed)
+        if (!_attachedManagers.ContainsKey(manager.Info.Metadata.InfoHash))
         {
-            throw new InvalidOperationException(
-                "Unable to detach torrent from session. Ensure the torrent is attached to this session.");
+            throw new InvalidOperationException("Unable to detach torrent from session. Ensure the torrent is attached to this session.");
         }
 
         manager.Stop();
         NativeMethods.DetachTorrent(_handle, manager.TorrentSessionHandle);
-
-        // mark as disposed/detached to stop usage of any remaining references to the manager
-        manager.MarkAsDetached();
     }
 
     /// <summary>

--- a/csdl/TorrentClient.cs
+++ b/csdl/TorrentClient.cs
@@ -17,6 +17,8 @@ namespace csdl;
 /// </summary>
 public class TorrentClient : IDisposable
 {
+    private const AlertCategories RequiredCategories = AlertCategories.Status | AlertCategories.Error;
+
     private readonly ConcurrentDictionary<string, TorrentManager> _attachedManagers = new(StringComparer.OrdinalIgnoreCase);
 
     // need to keep a reference to the delegate to prevent GC invalidating it
@@ -40,8 +42,10 @@ public class TorrentClient : IDisposable
             private_mode = config.PrivateMode,
             block_seeding = config.BlockSeeding,
             max_connections = config.MaxConnections,
-            all_events = config.IncludeAllAlertEvents,
-            force_encryption = config.ForceEncryption
+            force_encryption = config.ForceEncryption,
+
+            set_alert_flags = true,
+            alert_flags = (uint)(config.AlertCategories | RequiredCategories)
         });
 
         if (_handle <= IntPtr.Zero)

--- a/csdl/TorrentClientConfig.cs
+++ b/csdl/TorrentClientConfig.cs
@@ -1,6 +1,8 @@
 // csdl - a cross-platform libtorrent wrapper for .NET
 // Licensed under Apache-2.0 - see the license file for more information
 
+using csdl.Enums;
+
 namespace csdl;
 
 public class TorrentClientConfig
@@ -9,10 +11,15 @@ public class TorrentClientConfig
 
     public string Fingerprint { get; set; }
 
-    public bool IncludeAllAlertEvents { get; set; }
     public bool PrivateMode { get; set; }
     public bool BlockSeeding { get; set; }
     public bool ForceEncryption { get; set; }
+
+    /// <summary>
+    /// The alert categories to enable events for.
+    /// Some types of alerts are always enabled to ensure the client functions correctly.
+    /// </summary>
+    public AlertCategories AlertCategories { get; set; }
 
     public int MaxConnections { get; set; } = 200;
 }

--- a/csdl/csdl.csproj
+++ b/csdl/csdl.csproj
@@ -33,7 +33,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="csdl.Native" Version="1.0.2"/>
+      <PackageReference Include="csdl.Native" Version="1.1.0" />
     </ItemGroup>
 
 </Project>

--- a/native/include/structs.h
+++ b/native/include/structs.h
@@ -17,10 +17,12 @@ typedef struct cs_session_config {
     char* user_agent;
     char* fingerprint;
 
-    bool all_events;
     bool private_mode;
     bool block_seeding;
     bool encrypted_peers_only;
+
+    bool set_alert_flags;
+    uint32_t alert_flags;
 
     int32_t max_connections;
 } session_config;

--- a/native/src/library.cpp
+++ b/native/src/library.cpp
@@ -36,8 +36,8 @@ lt::session* create_session(session_config* config) {
     }
 
     // events
-    if (config->all_events) {
-        auto mask = lt::alert_category::all;
+    if (config->set_alert_flags) {
+        auto mask = static_cast<lt::alert_category_t>(config->alert_flags);
         pack.set_int(lt::settings_pack::alert_mask, mask);
     }
 


### PR DESCRIPTION
- Changes the configuration to allow alert categories (`AlertCategories` flag) and enforces a minimum set of flags (status and error) to be always enabled.
- Fixes incorrect hashes being sent back with the `TorrentRemovedAlert` and changes unknown hashes to fill with `FF`. Tests updated and report if the download fails to cleanup (but doesn't fail)
- Defers active torrent removal until the event is invoked (to allow removal events to be propagated to all listeners)

