### PR TITLE
Use SettingsPack for TorrentClientConfig presets

### DIFF
--- a/csdl/Native/NativeMethods.cs
+++ b/csdl/Native/NativeMethods.cs
@@ -18,19 +18,11 @@ internal static partial class NativeMethods
     public delegate void SessionEventCallback(IntPtr alertPtr);
 
     /// <summary>
-    /// Creates a session with the given configuration.
-    /// </summary>
-    /// <param name="config">The configuration to apply</param>
-    /// <returns>A handle to the session</returns>
-    [DllImport(LibraryName, EntryPoint = "create_session")]
-    public static extern IntPtr CreateSession(in NativeStructs.SessionConfig config);
-
-    /// <summary>
     /// Creates a session, optionally using a provided settings pack.
     /// </summary>
-    /// <param name="settingsPack">A settings pack handle, set to <see cref="IntPtr.Zero"/> to initialise without customisation</param>
+    /// <param name="settingsPack">A settings pack handle, set to <c>null</c> to initialise without customisation</param>
     /// <returns>A handle to the session</returns>
-    [LibraryImport(LibraryName, EntryPoint = "create_session_from_pack")]
+    [LibraryImport(LibraryName, EntryPoint = "create_session")]
     public static unsafe partial IntPtr CreateSession(void* settingsPack);
 
     /// <summary>

--- a/csdl/Native/NativeStructs.cs
+++ b/csdl/Native/NativeStructs.cs
@@ -9,34 +9,6 @@ namespace csdl.Native;
 internal static class NativeStructs
 {
     /// <summary>
-    /// Holds configuration information relating to a session.
-    /// </summary>
-    [StructLayout(LayoutKind.Sequential, Pack = 8)]
-    public struct SessionConfig
-    {
-        [MarshalAs(UnmanagedType.LPStr)]
-        public string user_agent;
-
-        [MarshalAs(UnmanagedType.LPStr)]
-        public string fingerprint;
-
-        [MarshalAs(UnmanagedType.I1)]
-        public bool private_mode;
-
-        [MarshalAs(UnmanagedType.I1)]
-        public bool block_seeding;
-
-        [MarshalAs(UnmanagedType.I1)]
-        public bool force_encryption;
-
-        [MarshalAs(UnmanagedType.I1)]
-        public bool set_alert_flags;
-
-        public int alert_flags;
-        public int max_connections;
-    }
-
-    /// <summary>
     /// Represents a file contained within a torrent.
     /// </summary>
     [StructLayout(LayoutKind.Sequential, Pack = 8)]

--- a/csdl/TorrentClientConfig.cs
+++ b/csdl/TorrentClientConfig.cs
@@ -21,5 +21,41 @@ public class TorrentClientConfig
     /// </summary>
     public AlertCategories AlertCategories { get; set; }
 
-    public int MaxConnections { get; set; } = 200;
+    public int? MaxConnections { get; set; } = 200;
+
+    public SettingsPack Build()
+    {
+        var pack = new SettingsPack();
+
+        // user-agent
+        if (!string.IsNullOrEmpty(UserAgent))
+        {
+            pack.Set("user_agent", UserAgent);
+        }
+
+        // fingerprint
+        if (!string.IsNullOrEmpty(Fingerprint))
+        {
+            pack.Set("peer_fingerprint", Fingerprint);
+        }
+
+        // events
+        pack.Set("alert_mask", (int)AlertCategories);
+
+        pack.Set("anonymous_mode", PrivateMode);
+        pack.Set("seeding_outgoing_connections", !BlockSeeding);
+
+        if (MaxConnections.HasValue)
+        {
+            pack.Set("connections_limit", MaxConnections.Value);
+        }
+
+        if (ForceEncryption)
+        {
+            pack.Set("out_enc_policy", 0);
+            pack.Set("in_enc_policy", 0);
+        }
+
+        return pack;
+    }
 }

--- a/native/include/library.h
+++ b/native/include/library.h
@@ -17,9 +17,7 @@ extern "C" {
 #endif
 
     // session control
-    CSDL_EXPORT lt::session* create_session(session_config* config);
-    CSDL_EXPORT lt::session* create_session_from_pack(lt::settings_pack* pack);
-
+    CSDL_EXPORT lt::session* create_session(lt::settings_pack* pack);
     CSDL_EXPORT void destroy_session(lt::session* session);
 
     CSDL_EXPORT void set_event_callback(lt::session* session, cs_alert_callback callback, bool include_unmapped_events);

--- a/native/include/structs.h
+++ b/native/include/structs.h
@@ -14,21 +14,6 @@
 extern "C" {
 #endif
 
-CSDL_STRUCT typedef struct cs_session_config {
-    // see https://www.libtorrent.org/reference-Settings.html#settings_pack
-    char* user_agent;
-    char* fingerprint;
-
-    bool private_mode;
-    bool block_seeding;
-    bool encrypted_peers_only;
-
-    bool set_alert_flags;
-
-    int32_t alert_flags;
-    int32_t max_connections;
-} session_config;
-
 CSDL_STRUCT typedef struct cs_torrent_file_information {
     lt::file_index_t index;
 

--- a/native/src/library.cpp
+++ b/native/src/library.cpp
@@ -9,67 +9,8 @@
 #include <libtorrent/torrent_handle.hpp>
 
 extern "C" {
-// given a config, create a session
-lt::session* create_session(session_config* config)
-{
-    if (config == nullptr)
-    {
-        return create_session_from_pack(nullptr);
-    }
 
-    lt::settings_pack pack;
-
-    // user-agent
-    if (config->user_agent != nullptr)
-    {
-        auto useragent = std::string(config->user_agent);
-        if (!useragent.empty())
-        {
-            pack.set_str(lt::settings_pack::user_agent, useragent);
-        }
-    }
-
-    // fingerprint
-    if (config->fingerprint != nullptr)
-    {
-        auto fingerprint = std::string(config->fingerprint);
-        if (!fingerprint.empty())
-        {
-            pack.set_str(lt::settings_pack::peer_fingerprint, fingerprint);
-        }
-    }
-
-    // events
-    if (config->set_alert_flags)
-    {
-        pack.set_int(lt::settings_pack::alert_mask, config->alert_flags);
-    }
-
-    pack.set_bool(lt::settings_pack::anonymous_mode, config->private_mode);
-
-    // disable seeding
-    if (config->block_seeding)
-    {
-        pack.set_bool(lt::settings_pack::seeding_outgoing_connections, false);
-    }
-
-    // max connections
-    if (config->max_connections > 0)
-    {
-        pack.set_int(lt::settings_pack::connections_limit, config->max_connections);
-    }
-
-    // encryption
-    if (config->encrypted_peers_only)
-    {
-        pack.set_int(lt::settings_pack::out_enc_policy, lt::settings_pack::pe_forced);
-        pack.set_int(lt::settings_pack::in_enc_policy, lt::settings_pack::pe_forced);
-    }
-
-    return create_session_from_pack(&pack);
-}
-
-lt::session* create_session_from_pack(lt::settings_pack* pack)
+lt::session* create_session(lt::settings_pack* pack)
 {
     lt::session_params params;
 


### PR DESCRIPTION
Currently, there's two ways to create a client in native code: by passing a `cs_session_config` struct or by using a `settings_pack`.

This removes the `cs_session_config` struct and related methods, using the new `SettingsPack` to reduce the native surface of the library and make it easier to provide additional customisation.

Note: Needs a new csdl-native bundle and is NOT backwards compatible with previous versions (built bundle available at https://github.com/aspriddell/csdl/actions/runs/10863030838)