### PR TITLE
Use common types in structs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ include_directories(${CMAKE_BINARY_DIR}/include native/include)
 set(CMAKE_CXX_STANDARD 20)
 set(PRODUCT_VERSION_MAJOR 1)
 set(PRODUCT_VERSION_MINOR 2)
-set(PRODUCT_VERSION_PATCH 0)
+set(PRODUCT_VERSION_PATCH 1)
 
 # build target versions
 if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")

--- a/csdl/Native/NativeMethods.cs
+++ b/csdl/Native/NativeMethods.cs
@@ -18,19 +18,11 @@ internal static partial class NativeMethods
     public delegate void SessionEventCallback(IntPtr alertPtr);
 
     /// <summary>
-    /// Creates a session with the given configuration.
-    /// </summary>
-    /// <param name="config">The configuration to apply</param>
-    /// <returns>A handle to the session</returns>
-    [DllImport(LibraryName, EntryPoint = "create_session")]
-    public static extern IntPtr CreateSession(in NativeStructs.SessionConfig config);
-
-    /// <summary>
     /// Creates a session, optionally using a provided settings pack.
     /// </summary>
-    /// <param name="settingsPack">A settings pack handle, set to <see cref="IntPtr.Zero"/> to initialise without customisation</param>
+    /// <param name="settingsPack">A settings pack handle, set to <c>null</c> to initialise without customisation</param>
     /// <returns>A handle to the session</returns>
-    [LibraryImport(LibraryName, EntryPoint = "create_session_from_pack")]
+    [LibraryImport(LibraryName, EntryPoint = "create_session")]
     public static unsafe partial IntPtr CreateSession(void* settingsPack);
 
     /// <summary>

--- a/csdl/Native/NativeStructs.cs
+++ b/csdl/Native/NativeStructs.cs
@@ -9,34 +9,6 @@ namespace csdl.Native;
 internal static class NativeStructs
 {
     /// <summary>
-    /// Holds configuration information relating to a session.
-    /// </summary>
-    [StructLayout(LayoutKind.Sequential, Pack = 8)]
-    public struct SessionConfig
-    {
-        [MarshalAs(UnmanagedType.LPStr)]
-        public string user_agent;
-
-        [MarshalAs(UnmanagedType.LPStr)]
-        public string fingerprint;
-
-        [MarshalAs(UnmanagedType.I1)]
-        public bool private_mode;
-
-        [MarshalAs(UnmanagedType.I1)]
-        public bool block_seeding;
-
-        [MarshalAs(UnmanagedType.I1)]
-        public bool force_encryption;
-
-        [MarshalAs(UnmanagedType.I1)]
-        public bool set_alert_flags;
-
-        public int alert_flags;
-        public int max_connections;
-    }
-
-    /// <summary>
     /// Represents a file contained within a torrent.
     /// </summary>
     [StructLayout(LayoutKind.Sequential, Pack = 8)]

--- a/csdl/TorrentClientConfig.cs
+++ b/csdl/TorrentClientConfig.cs
@@ -21,5 +21,41 @@ public class TorrentClientConfig
     /// </summary>
     public AlertCategories AlertCategories { get; set; }
 
-    public int MaxConnections { get; set; } = 200;
+    public int? MaxConnections { get; set; } = 200;
+
+    public SettingsPack Build()
+    {
+        var pack = new SettingsPack();
+
+        // user-agent
+        if (!string.IsNullOrEmpty(UserAgent))
+        {
+            pack.Set("user_agent", UserAgent);
+        }
+
+        // fingerprint
+        if (!string.IsNullOrEmpty(Fingerprint))
+        {
+            pack.Set("peer_fingerprint", Fingerprint);
+        }
+
+        // events
+        pack.Set("alert_mask", (int)AlertCategories);
+
+        pack.Set("anonymous_mode", PrivateMode);
+        pack.Set("seeding_outgoing_connections", !BlockSeeding);
+
+        if (MaxConnections.HasValue)
+        {
+            pack.Set("connections_limit", MaxConnections.Value);
+        }
+
+        if (ForceEncryption)
+        {
+            pack.Set("out_enc_policy", 0);
+            pack.Set("in_enc_policy", 0);
+        }
+
+        return pack;
+    }
 }

--- a/native/include/library.h
+++ b/native/include/library.h
@@ -42,8 +42,8 @@ extern "C" {
     CSDL_EXPORT void destroy_torrent_file_list(torrent_file_list* file_list);
 
     // priority control
-    CSDL_EXPORT uint8_t get_file_dl_priority(lt::torrent_handle* torrent, lt::file_index_t file_index);
-    CSDL_EXPORT void set_file_dl_priority(lt::torrent_handle* torrent, lt::file_index_t file_index, uint8_t priority);
+    CSDL_EXPORT uint8_t get_file_dl_priority(lt::torrent_handle* torrent, int32_t file_index);
+    CSDL_EXPORT void set_file_dl_priority(lt::torrent_handle* torrent, int32_t file_index, uint8_t priority);
 
     // download control
     CSDL_EXPORT void start_torrent(lt::torrent_handle* torrent);

--- a/native/include/library.h
+++ b/native/include/library.h
@@ -17,9 +17,7 @@ extern "C" {
 #endif
 
     // session control
-    CSDL_EXPORT lt::session* create_session(session_config* config);
-    CSDL_EXPORT lt::session* create_session_from_pack(lt::settings_pack* pack);
-
+    CSDL_EXPORT lt::session* create_session(lt::settings_pack* pack);
     CSDL_EXPORT void destroy_session(lt::session* session);
 
     CSDL_EXPORT void set_event_callback(lt::session* session, cs_alert_callback callback, bool include_unmapped_events);

--- a/native/include/structs.h
+++ b/native/include/structs.h
@@ -14,21 +14,6 @@
 extern "C" {
 #endif
 
-CSDL_STRUCT typedef struct cs_session_config {
-    // see https://www.libtorrent.org/reference-Settings.html#settings_pack
-    char* user_agent;
-    char* fingerprint;
-
-    bool private_mode;
-    bool block_seeding;
-    bool encrypted_peers_only;
-
-    bool set_alert_flags;
-
-    int32_t alert_flags;
-    int32_t max_connections;
-} session_config;
-
 CSDL_STRUCT typedef struct cs_torrent_file_information {
     lt::file_index_t index;
 

--- a/native/include/structs.h
+++ b/native/include/structs.h
@@ -15,7 +15,7 @@ extern "C" {
 #endif
 
 CSDL_STRUCT typedef struct cs_torrent_file_information {
-    lt::file_index_t index;
+    int32_t index;
 
     int64_t offset;
     int64_t file_size;

--- a/native/src/library.cpp
+++ b/native/src/library.cpp
@@ -228,14 +228,16 @@ void get_torrent_file_list(lt::torrent_info* torrent, torrent_file_list* file_li
 
     for (lt::file_index_t i(0); i != files.end_file(); i++)
     {
+        auto index = static_cast<int32_t>(i);
+
         auto name = files.file_name(i);
         auto path = files.file_path(i);
 
         char* file_name = new char[name.size() + 1]();
         char* file_path = new char[path.size() + 1]();
 
-        list[(int)i] = {
-            i,
+        list[index] = {
+            index,
             files.file_offset(i),
             files.file_size(i),
             files.mtime(i),
@@ -270,25 +272,25 @@ void destroy_torrent_file_list(torrent_file_list* file_list)
 }
 
 // set the download priority for a file in a torrent.
-void set_file_dl_priority(lt::torrent_handle* torrent, const lt::file_index_t file_index, const uint8_t priority)
+void set_file_dl_priority(lt::torrent_handle* torrent, const int32_t file_index, const uint8_t priority)
 {
     if (torrent == nullptr)
     {
         return;
     }
 
-    torrent->file_priority(file_index, (lt::download_priority_t)priority);
+    torrent->file_priority(static_cast<lt::file_index_t>(file_index), static_cast<lt::download_priority_t>(priority));
 }
 
 // get the download priority for a file in a torrent.
-uint8_t get_file_dl_priority(lt::torrent_handle* torrent, const lt::file_index_t file_index)
+uint8_t get_file_dl_priority(lt::torrent_handle* torrent, const int32_t file_index)
 {
     if (torrent == nullptr)
     {
         return 0;
     }
 
-    return (uint8_t)torrent->file_priority(file_index);
+    return static_cast<uint8_t>(torrent->file_priority(static_cast<lt::file_index_t>(file_index)));
 }
 
 // start and stop the download of a torrent.

--- a/native/src/library.cpp
+++ b/native/src/library.cpp
@@ -115,7 +115,7 @@ lt::torrent_handle* attach_torrent(lt::session* session, lt::torrent_info* torre
 
     // set torrent info - make_shared creates a copy
     params.ti = std::make_shared<lt::torrent_info>(*torrent);
-    auto handle = new lt::torrent_handle(session->add_torrent(params));
+    const auto handle = new lt::torrent_handle(session->add_torrent(params));
 
     if (handle->is_valid())
     {
@@ -154,15 +154,15 @@ torrent_metadata* get_torrent_info(lt::torrent_info* torrent)
     auto author = torrent->creator();
     auto comment = torrent->comment();
 
-    auto torrent_name = new char[name.size() + 1]();
-    auto torrent_author = new char[author.size() + 1]();
-    auto torrent_comment = new char[comment.size() + 1]();
+    const auto torrent_name = new char[name.size() + 1]();
+    const auto torrent_author = new char[author.size() + 1]();
+    const auto torrent_comment = new char[comment.size() + 1]();
 
     std::ranges::copy(name, torrent_name);
     std::ranges::copy(author, torrent_author);
     std::ranges::copy(comment, torrent_comment);
 
-    auto info = new torrent_metadata();
+    const auto info = new torrent_metadata();
 
     info->name = torrent_name;
     info->creator = torrent_author;
@@ -221,8 +221,8 @@ void get_torrent_file_list(lt::torrent_info* torrent, torrent_file_list* file_li
 
     const auto& files = torrent->files();
 
-    auto num_files = files.num_files();
-    auto list = new torrent_file_information[num_files];
+    const auto num_files = files.num_files();
+    const auto list = new torrent_file_information[num_files];
 
     for (lt::file_index_t i(0); i != files.end_file(); i++)
     {
@@ -231,8 +231,8 @@ void get_torrent_file_list(lt::torrent_info* torrent, torrent_file_list* file_li
         auto name = files.file_name(i);
         auto path = files.file_path(i);
 
-        char* file_name = new char[name.size() + 1]();
-        char* file_path = new char[path.size() + 1]();
+        auto file_name = new char[name.size() + 1]();
+        auto file_path = new char[path.size() + 1]();
 
         list[index] = {
             index,
@@ -338,7 +338,7 @@ void get_torrent_status(lt::torrent_handle* torrent, torrent_status* torrent_sta
         return;
     }
 
-    auto s = torrent->status();
+    const auto s = torrent->status();
 
     if (s.errc != lt::error_code())
     {

--- a/native/src/library.cpp
+++ b/native/src/library.cpp
@@ -9,67 +9,8 @@
 #include <libtorrent/torrent_handle.hpp>
 
 extern "C" {
-// given a config, create a session
-lt::session* create_session(session_config* config)
-{
-    if (config == nullptr)
-    {
-        return create_session_from_pack(nullptr);
-    }
 
-    lt::settings_pack pack;
-
-    // user-agent
-    if (config->user_agent != nullptr)
-    {
-        auto useragent = std::string(config->user_agent);
-        if (!useragent.empty())
-        {
-            pack.set_str(lt::settings_pack::user_agent, useragent);
-        }
-    }
-
-    // fingerprint
-    if (config->fingerprint != nullptr)
-    {
-        auto fingerprint = std::string(config->fingerprint);
-        if (!fingerprint.empty())
-        {
-            pack.set_str(lt::settings_pack::peer_fingerprint, fingerprint);
-        }
-    }
-
-    // events
-    if (config->set_alert_flags)
-    {
-        pack.set_int(lt::settings_pack::alert_mask, config->alert_flags);
-    }
-
-    pack.set_bool(lt::settings_pack::anonymous_mode, config->private_mode);
-
-    // disable seeding
-    if (config->block_seeding)
-    {
-        pack.set_bool(lt::settings_pack::seeding_outgoing_connections, false);
-    }
-
-    // max connections
-    if (config->max_connections > 0)
-    {
-        pack.set_int(lt::settings_pack::connections_limit, config->max_connections);
-    }
-
-    // encryption
-    if (config->encrypted_peers_only)
-    {
-        pack.set_int(lt::settings_pack::out_enc_policy, lt::settings_pack::pe_forced);
-        pack.set_int(lt::settings_pack::in_enc_policy, lt::settings_pack::pe_forced);
-    }
-
-    return create_session_from_pack(&pack);
-}
-
-lt::session* create_session_from_pack(lt::settings_pack* pack)
+lt::session* create_session(lt::settings_pack* pack)
 {
     lt::session_params params;
 

--- a/native/src/library.cpp
+++ b/native/src/library.cpp
@@ -49,7 +49,8 @@ void set_event_callback(lt::session* session, cs_alert_callback callback, bool i
     {
         return;
     }
-    else if (callback == nullptr)
+
+    if (callback == nullptr)
     {
         clear_event_callback(session);
         return;
@@ -75,8 +76,8 @@ void clear_event_callback(lt::session* session)
 
 lt::torrent_info* create_torrent_bytes(const char* data, long length)
 {
-    lt::span<char const> buffer(data, length);
-    lt::load_torrent_limits cfg;
+    const lt::span buffer(data, length);
+    const lt::load_torrent_limits cfg;
 
     return new lt::torrent_info(buffer, cfg, lt::from_span);
 }
@@ -88,10 +89,7 @@ lt::torrent_info* create_torrent_file(const char* file_path)
 
 void destroy_torrent(lt::torrent_info* torrent)
 {
-    if (torrent != nullptr)
-    {
-        delete torrent;
-    }
+    delete torrent;
 }
 
 // attach a torrent to the session, returning a handle that can be used to control the download.
@@ -160,9 +158,9 @@ torrent_metadata* get_torrent_info(lt::torrent_info* torrent)
     auto torrent_author = new char[author.size() + 1]();
     auto torrent_comment = new char[comment.size() + 1]();
 
-    std::copy(name.begin(), name.end(), torrent_name);
-    std::copy(author.begin(), author.end(), torrent_author);
-    std::copy(comment.begin(), comment.end(), torrent_comment);
+    std::ranges::copy(name, torrent_name);
+    std::ranges::copy(author, torrent_author);
+    std::ranges::copy(comment, torrent_comment);
 
     auto info = new torrent_metadata();
 
@@ -179,21 +177,21 @@ torrent_metadata* get_torrent_info(lt::torrent_info* torrent)
     // fill in the info hash
     if (hash.has_v1())
     {
-        std::copy(hash.v1.begin(), hash.v1.end(), info->info_hash_v1);
+        std::ranges::copy(hash.v1, info->info_hash_v1);
     }
     else
     {
-        std::fill(info->info_hash_v1, info->info_hash_v1 + 20, 0);
+        std::fill_n(info->info_hash_v1, 20, 0);
     }
 
     // fill in the info hash v2
     if (hash.has_v2())
     {
-        std::copy(hash.v2.begin(), hash.v2.end(), info->info_hash_v2);
+        std::ranges::copy(hash.v2, info->info_hash_v2);
     }
     else
     {
-        std::fill(info->info_hash_v2, info->info_hash_v2 + 32, 0);
+        std::fill_n(info->info_hash_v2, 32, 0);
     }
 
     return info;
@@ -247,8 +245,8 @@ void get_torrent_file_list(lt::torrent_info* torrent, torrent_file_list* file_li
             files.pad_file_at(i)
         };
 
-        std::copy(name.begin(), name.end(), file_name);
-        std::copy(path.begin(), path.end(), file_path);
+        std::ranges::copy(name, file_name);
+        std::ranges::copy(path, file_path);
     }
 
     file_list->files = list;


### PR DESCRIPTION
Depends on #10 

Cleans up native library files to use const more often, applies clang-tidy recommendations where valid and removes all special type aliases in favour of static_casts from common, well-known types